### PR TITLE
test: break early in matchImage loop

### DIFF
--- a/test/__tests__/jestMatchers.test.ts
+++ b/test/__tests__/jestMatchers.test.ts
@@ -44,9 +44,10 @@ describe('toMatchImage', () => {
   });
 
   it('should throw if data is different', () => {
-    const image1 = new IJS(2, 2);
-    const image2 = new IJS(2, 2);
+    const image1 = new IJS(2, 3);
+    const image2 = new IJS(2, 3);
     image2.setValue(1, 0, 0, 128);
+    image2.setValue(2, 0, 0, 255);
     expect(() => expect(image1).toMatchImage(image2)).toThrow(
       /Expected pixel at \(0, 1\) to be \[128, 0, 0\], but got \[0, 0, 0\]/,
     );

--- a/test/jestMatchers.ts
+++ b/test/jestMatchers.ts
@@ -31,7 +31,7 @@ export function toMatchImage(
   } else if (received.colorModel !== expectedImage.colorModel) {
     error = `Expected image color model to be ${expectedImage.colorModel}, but got ${received.colorModel}`;
   } else {
-    for (let row = 0; row < received.height; row++) {
+    rowsLoop: for (let row = 0; row < received.height; row++) {
       for (let col = 0; col < received.width; col++) {
         const receivedPixel = received.getPixel(row, col);
         const expectedPixel = expectedImage.getPixel(row, col);
@@ -39,7 +39,7 @@ export function toMatchImage(
           error = `Expected pixel at (${col}, ${row}) to be [${expectedPixel.join(
             ', ',
           )}], but got [${receivedPixel.join(', ')}]`;
-          break;
+          break rowsLoop;
         }
       }
     }


### PR DESCRIPTION
It's better for performance and the user if we report the first error that is seen.
