### PR TITLE
Implement `floodFill()`

### DIFF
--- a/src/Mask.ts
+++ b/src/Mask.ts
@@ -3,6 +3,8 @@ import {
   AndOptions,
   invert,
   InvertOptions,
+  or,
+  OrOptions,
   subtractImage,
   SubtractImageOptions,
 } from './filters';
@@ -339,7 +341,16 @@ export class Mask {
   public and(other: Mask, options?: AndOptions): Mask {
     return and(this, other, options);
   }
-
+  /**
+   * Perform an OR operation on two masks.
+   *
+   * @param other - Second mask.
+   * @param options - And options.
+   * @returns OR of the two masks.
+   */
+  public or(other: Mask, options?: OrOptions): Mask {
+    return or(this, other, options);
+  }
   // MORPHOLOGY
   /**
    * Erode a Mask.

--- a/src/Mask.ts
+++ b/src/Mask.ts
@@ -18,6 +18,8 @@ import {
   dilate,
   DilateOptions,
   ErodeOptions,
+  floodFill,
+  FloodFillOptions,
   morphologicalGradient,
   MorphologicalGradientOptions,
   open,
@@ -351,6 +353,7 @@ export class Mask {
   public or(other: Mask, options?: OrOptions): Mask {
     return or(this, other, options);
   }
+
   // MORPHOLOGY
   /**
    * Erode a Mask.
@@ -430,6 +433,15 @@ export class Mask {
    */
   public clearBorder(options?: ClearBorderOptions): Mask {
     return clearBorder(this, options);
+  }
+  /**
+   * Remove elements connected to the borders of an image.
+   *
+   * @param options - Clear border options.
+   * @returns The processed image.
+   */
+  public floodFill(options?: FloodFillOptions): Mask {
+    return floodFill(this, options);
   }
 }
 

--- a/src/Mask.ts
+++ b/src/Mask.ts
@@ -1,4 +1,6 @@
 import {
+  and,
+  AndOptions,
   invert,
   InvertOptions,
   subtractImage,
@@ -326,6 +328,16 @@ export class Mask {
    */
   public subtractImage(other: Mask, options?: SubtractImageOptions): Mask {
     return subtractImage(this, other, options);
+  }
+  /**
+   * Perform an AND operation on two masks.
+   *
+   * @param other - Second mask.
+   * @param options - And options.
+   * @returns AND of the two masks.
+   */
+  public and(other: Mask, options?: AndOptions): Mask {
+    return and(this, other, options);
   }
 
   // MORPHOLOGY

--- a/src/Mask.ts
+++ b/src/Mask.ts
@@ -435,10 +435,10 @@ export class Mask {
     return clearBorder(this, options);
   }
   /**
-   * Remove elements connected to the borders of an image.
+   * Fill holes in regions of interest.
    *
-   * @param options - Clear border options.
-   * @returns The processed image.
+   * @param options - Flood fill options.
+   * @returns The filled mask.
    */
   public floodFill(options?: FloodFillOptions): Mask {
     return floodFill(this, options);

--- a/src/filters/__tests__/and.test.ts
+++ b/src/filters/__tests__/and.test.ts
@@ -1,0 +1,19 @@
+describe('and', () => {
+  it('mask AND itself', () => {
+    const image = testUtils.createMask([[1, 1, 1, 1, 1, 1, 1, 1]]);
+    const other = image;
+    expect(image.and(other)).toMatchMaskData([[1, 1, 1, 1, 1, 1, 1, 1]]);
+  });
+  it('two different masks', () => {
+    const image = testUtils.createMask([[0, 0, 0, 0, 1, 1, 1, 1]]);
+    const other = testUtils.createMask([[1, 1, 1, 1, 0, 0, 0, 0]]);
+    expect(image.and(other)).toMatchMaskData([[0, 0, 0, 0, 0, 0, 0, 0]]);
+  });
+  it('different size error', () => {
+    const image = testUtils.createMask([[0, 0, 0, 0, 1, 1, 1, 1]]);
+    const other = testUtils.createMask([[1, 1, 1, 0, 0, 0]]);
+    expect(() => {
+      image.and(other);
+    }).toThrow('subtractImage: both images must have the same size');
+  });
+});

--- a/src/filters/__tests__/and.test.ts
+++ b/src/filters/__tests__/and.test.ts
@@ -14,6 +14,6 @@ describe('and', () => {
     const other = testUtils.createMask([[1, 1, 1, 0, 0, 0]]);
     expect(() => {
       image.and(other);
-    }).toThrow('subtractImage: both images must have the same size');
+    }).toThrow('and: both masks must have the same size');
   });
 });

--- a/src/filters/__tests__/or.test.ts
+++ b/src/filters/__tests__/or.test.ts
@@ -1,0 +1,24 @@
+describe('or', () => {
+  it('mask OR itself', () => {
+    const image = testUtils.createMask([[1, 1, 1, 1, 1, 1, 1, 1]]);
+    const other = image;
+    expect(image.or(other)).toMatchMaskData([[1, 1, 1, 1, 1, 1, 1, 1]]);
+  });
+  it('two different masks', () => {
+    const image = testUtils.createMask([[0, 0, 0, 0, 1, 1, 1, 1]]);
+    const other = testUtils.createMask([[1, 1, 1, 1, 0, 0, 0, 0]]);
+    expect(image.or(other)).toMatchMaskData([[1, 1, 1, 1, 1, 1, 1, 1]]);
+  });
+  it('test when OR returns 0', () => {
+    const image = testUtils.createMask([[0, 0, 0, 0, 1, 1, 1, 1]]);
+    const other = testUtils.createMask([[0, 1, 0, 1, 0, 0, 0, 0]]);
+    expect(image.or(other)).toMatchMaskData([[0, 1, 0, 1, 1, 1, 1, 1]]);
+  });
+  it('different size error', () => {
+    const image = testUtils.createMask([[0, 0, 0, 0, 1, 1, 1, 1]]);
+    const other = testUtils.createMask([[1, 1, 1, 0, 0, 0]]);
+    expect(() => {
+      image.or(other);
+    }).toThrow('or: both masks must have the same size');
+  });
+});

--- a/src/filters/and.ts
+++ b/src/filters/and.ts
@@ -1,0 +1,34 @@
+import { Mask } from '..';
+import { maskToOutputMask } from '../utils/getOutputImage';
+
+export interface AndOptions {
+  /**
+   * Image to which the inverted image has to be put.
+   */
+  out?: Mask;
+}
+
+/**
+ * Perform an AND operation on two masks.
+ *
+ * @param mask - First mask.
+ * @param otherMask - Second mask.
+ * @param options - And options.
+ * @returns AND of the two masks.
+ */
+export function and(mask: Mask, otherMask: Mask, options?: AndOptions): Mask {
+  const newMask = maskToOutputMask(mask, options);
+
+  if (mask.width !== otherMask.width || mask.height !== otherMask.height) {
+    throw new Error('subtractImage: both images must have the same size');
+  }
+
+  for (let i = 0; i < newMask.size; i++) {
+    if (mask.getBitByIndex(i) && otherMask.getBitByIndex(i)) {
+      newMask.setBitByIndex(i, 1);
+    } else {
+      newMask.setBitByIndex(i, 0);
+    }
+  }
+  return newMask;
+}

--- a/src/filters/index.ts
+++ b/src/filters/index.ts
@@ -4,3 +4,4 @@ export * from './convolution';
 export * from './blur';
 export * from './subtractImage';
 export * from './and';
+export * from './or';

--- a/src/filters/index.ts
+++ b/src/filters/index.ts
@@ -3,3 +3,4 @@ export * from './gaussianBlur';
 export * from './convolution';
 export * from './blur';
 export * from './subtractImage';
+export * from './and';

--- a/src/filters/or.ts
+++ b/src/filters/or.ts
@@ -1,7 +1,7 @@
 import { Mask } from '..';
 import { maskToOutputMask } from '../utils/getOutputImage';
 
-export interface AndOptions {
+export interface OrOptions {
   /**
    * Image to which the inverted image has to be put.
    */
@@ -9,22 +9,22 @@ export interface AndOptions {
 }
 
 /**
- * Perform an AND operation on two masks.
+ * Perform an OR operation on two masks.
  *
  * @param mask - First mask.
  * @param otherMask - Second mask.
- * @param options - And options.
- * @returns AND of the two masks.
+ * @param options - Or options.
+ * @returns OR of the two masks.
  */
-export function and(mask: Mask, otherMask: Mask, options?: AndOptions): Mask {
+export function or(mask: Mask, otherMask: Mask, options?: OrOptions): Mask {
   const newMask = maskToOutputMask(mask, options);
 
   if (mask.width !== otherMask.width || mask.height !== otherMask.height) {
-    throw new Error('and: both masks must have the same size');
+    throw new Error('or: both masks must have the same size');
   }
 
   for (let i = 0; i < newMask.size; i++) {
-    if (mask.getBitByIndex(i) && otherMask.getBitByIndex(i)) {
+    if (mask.getBitByIndex(i) || otherMask.getBitByIndex(i)) {
       newMask.setBitByIndex(i, 1);
     } else {
       newMask.setBitByIndex(i, 0);

--- a/src/morphology/__tests__/floodFill.test.ts
+++ b/src/morphology/__tests__/floodFill.test.ts
@@ -1,0 +1,115 @@
+import { Mask } from '../..';
+
+describe('floodFill', () => {
+  it('mask 5x5, default options', () => {
+    let image = testUtils.createMask([
+      [0, 0, 0, 0, 0],
+      [0, 1, 1, 1, 0],
+      [0, 1, 0, 1, 0],
+      [0, 1, 1, 1, 0],
+      [0, 0, 0, 0, 0],
+    ]);
+
+    expect(image.floodFill()).toMatchMaskData([
+      [0, 0, 0, 0, 0],
+      [0, 1, 1, 1, 0],
+      [0, 1, 1, 1, 0],
+      [0, 1, 1, 1, 0],
+      [0, 0, 0, 0, 0],
+    ]);
+  });
+  it('pixels touching border', () => {
+    let image = testUtils.createMask([
+      [0, 1, 0, 1, 0],
+      [0, 1, 1, 1, 0],
+      [0, 1, 0, 0, 1],
+      [0, 1, 1, 1, 0],
+      [0, 0, 0, 0, 0],
+    ]);
+
+    expect(image.floodFill()).toMatchMaskData([
+      [0, 1, 0, 1, 0],
+      [0, 1, 1, 1, 0],
+      [0, 1, 1, 1, 1],
+      [0, 1, 1, 1, 0],
+      [0, 0, 0, 0, 0],
+    ]);
+  });
+  it('mask should not change', () => {
+    let image = testUtils.createMask([
+      [0, 1, 0, 1, 0],
+      [0, 1, 1, 1, 0],
+      [0, 1, 0, 0, 0],
+      [0, 1, 1, 1, 0],
+      [0, 0, 0, 0, 0],
+    ]);
+
+    expect(image.floodFill()).toMatchMaskData([
+      [0, 1, 0, 1, 0],
+      [0, 1, 1, 1, 0],
+      [0, 1, 0, 0, 0],
+      [0, 1, 1, 1, 0],
+      [0, 0, 0, 0, 0],
+    ]);
+  });
+  it('allowCorners true', () => {
+    let image = testUtils.createMask([
+      [0, 0, 0, 0, 0],
+      [1, 1, 1, 1, 0],
+      [1, 0, 1, 0, 1],
+      [1, 1, 1, 1, 1],
+      [0, 0, 0, 0, 0],
+    ]);
+
+    expect(image.floodFill({ allowCorners: true })).toMatchMaskData([
+      [0, 0, 0, 0, 0],
+      [1, 1, 1, 1, 0],
+      [1, 1, 1, 0, 1],
+      [1, 1, 1, 1, 1],
+      [0, 0, 0, 0, 0],
+    ]);
+  });
+  it('1x1 mask', () => {
+    let image = testUtils.createMask([[0]]);
+
+    expect(image.floodFill({ allowCorners: true })).toMatchMaskData([[0]]);
+  });
+  it('Out option', () => {
+    let image = testUtils.createMask([
+      [0, 0, 0, 0, 0],
+      [0, 1, 1, 1, 0],
+      [0, 1, 0, 1, 0],
+      [0, 0, 1, 1, 0],
+      [0, 0, 0, 0, 0],
+    ]);
+
+    const out = new Mask(5, 5);
+
+    image.floodFill({ out });
+    expect(out).toMatchMaskData([
+      [0, 0, 0, 0, 0],
+      [0, 1, 1, 1, 0],
+      [0, 1, 1, 1, 0],
+      [0, 0, 1, 1, 0],
+      [0, 0, 0, 0, 0],
+    ]);
+  });
+  it('in place modification', () => {
+    let image = testUtils.createMask([
+      [0, 0, 0, 0, 0],
+      [0, 1, 1, 1, 0],
+      [0, 1, 0, 1, 0],
+      [0, 0, 1, 1, 0],
+      [0, 0, 1, 0, 0],
+    ]);
+
+    image.floodFill({ out: image });
+    expect(image).toMatchMaskData([
+      [0, 0, 0, 0, 0],
+      [0, 1, 1, 1, 0],
+      [0, 1, 1, 1, 0],
+      [0, 0, 1, 1, 0],
+      [0, 0, 1, 0, 0],
+    ]);
+  });
+});

--- a/src/morphology/clearBorder.ts
+++ b/src/morphology/clearBorder.ts
@@ -52,7 +52,7 @@ export function clearBorder(
     newImage.setBitByIndex(currentPixel, 0);
     if (to - from > MAX_ARRAY) {
       throw new Error(
-        'clearBorder could not process image, overflow in the data processing array.',
+        'clearBorder: could not process image, overflow in the data processing array.',
       );
     }
 

--- a/src/morphology/clearBorder.ts
+++ b/src/morphology/clearBorder.ts
@@ -3,6 +3,9 @@ import { borderIterator } from '../utils/borderIterator';
 import { maskToOutputMask } from '../utils/getOutputImage';
 
 export interface ClearBorderOptions {
+  /**
+   * Consider pixels connected by corners?
+   */
   allowCorners?: boolean;
   /**
    * Image to which the inverted image has to be put.

--- a/src/morphology/floodFill.ts
+++ b/src/morphology/floodFill.ts
@@ -22,10 +22,8 @@ export interface FloodFillOptions {
 export function floodFill(mask: Mask, options: FloodFillOptions = {}): Mask {
   let { allowCorners = false } = options;
 
-  let newImage = maskToOutputMask(mask, options);
-
+  let newImage = maskToOutputMask(mask, options, { clone: true });
   let inverted = mask.invert();
   let cleared = inverted.clearBorder({ allowCorners });
-
-  return newImage.or(cleared);
+  return newImage.or(cleared, { out: newImage });
 }

--- a/src/morphology/floodFill.ts
+++ b/src/morphology/floodFill.ts
@@ -1,19 +1,31 @@
-import { IJS, Mask } from '..';
+import { Mask } from '..';
+import { maskToOutputMask } from '../utils/getOutputImage';
 
 export interface FloodFillOptions {
   /**
    * Consider pixels connected by corners?
    */
-   allowCorners?: boolean;
-   /**
-    * Image to which the inverted image has to be put.
-    */
-   out?: Mask;
+  allowCorners?: boolean;
+  /**
+   * Image to which the inverted image has to be put.
+   */
+  out?: Mask;
+}
 
-export function floodFill(mask: Mask, options: FloodFillOptions): Mask {
-    let { allowCorners = false } = options;
+/**
+ * Fill holes in regions of interest.
+ *
+ * @param mask - Mask to process.
+ * @param options - Flood fill options.
+ * @returns The filled mask.
+ */
+export function floodFill(mask: Mask, options: FloodFillOptions = {}): Mask {
+  let { allowCorners = false } = options;
 
   let newImage = maskToOutputMask(mask, options);
 
+  let inverted = mask.invert();
+  let cleared = inverted.clearBorder({ allowCorners });
 
+  return newImage.or(cleared);
 }

--- a/src/morphology/floodFill.ts
+++ b/src/morphology/floodFill.ts
@@ -1,0 +1,19 @@
+import { IJS, Mask } from '..';
+
+export interface FloodFillOptions {
+  /**
+   * Consider pixels connected by corners?
+   */
+   allowCorners?: boolean;
+   /**
+    * Image to which the inverted image has to be put.
+    */
+   out?: Mask;
+
+export function floodFill(mask: Mask, options: FloodFillOptions): Mask {
+    let { allowCorners = false } = options;
+
+  let newImage = maskToOutputMask(mask, options);
+
+
+}

--- a/src/morphology/index.ts
+++ b/src/morphology/index.ts
@@ -6,3 +6,4 @@ export * from './topHat';
 export * from './bottomHat';
 export * from './morphologicalGradient';
 export * from './clearBorder';
+export * from './floodFill';


### PR DESCRIPTION
- feat: write border pixels iterator
- feat: rowColumToIndex
- feat: indexToRowColumn
- docs: enhance function doc
- feat: write clearBorder
- refactor: remove useless function
- test: add clearBorder test
- feat: add clone option to maskToOutputMask
- feat: add copyData
- fix (getOutputImage): fix bug with clone option
- fix (clearBorder): loop condition was wrong
- chore: remove console log
- feat: add and function
- feat: add OR function
- feat: start working on floodFill
- feat: first draft of floodFill
- test: write floodFill test
- docs: fix floodFill tsdoc
