### PR TITLE
Implement `getBorderPoints` et `paintMask`

### DIFF
--- a/demo/components/Home.tsx
+++ b/demo/components/Home.tsx
@@ -3,10 +3,10 @@ import { IJS } from '../../src';
 import CameraSelector from './CameraSelector';
 import CameraTransform from './CameraTransform';
 import Container from './Container';
-import { testExtractRoi } from './testFunctions/testExtract';
+import { testPaintMask } from './testFunctions/testPaintMask';
 
 function testTransform(image: IJS) {
-  return testExtractRoi(image);
+  return testPaintMask(image);
 }
 
 export default function Home() {

--- a/demo/components/testFunctions/testCopyTo.ts
+++ b/demo/components/testFunctions/testCopyTo.ts
@@ -8,20 +8,20 @@ import { IJS, ImageColorModel } from '../../../src';
  */
 export function testCopyTo(image: IJS): IJS {
   let result = image.copyTo(image, {
-    rowOffset: image.height / 2,
-    columnOffset: image.width / 2,
+    row: image.height / 2,
+    column: image.width / 2,
   });
   let blackSquare = new IJS(50, 50, { colorModel: ImageColorModel.RGBA });
   let redSquare = new IJS(150, 150, { colorModel: ImageColorModel.RGBA });
   redSquare.fillChannel(0, 255);
   redSquare.fillAlpha(100);
   result = blackSquare.copyTo(result, {
-    rowOffset: 200,
-    columnOffset: 300,
+    row: 200,
+    column: 300,
   });
   redSquare.copyTo(result, {
-    columnOffset: ((Date.now() / 10) >>> 0) % 500,
-    rowOffset: ((Date.now() / 10) >>> 0) % 500,
+    column: ((Date.now() / 10) >>> 0) % 500,
+    row: ((Date.now() / 10) >>> 0) % 500,
     out: result,
   });
   return result;

--- a/demo/components/testFunctions/testCrop.ts
+++ b/demo/components/testFunctions/testCrop.ts
@@ -42,5 +42,5 @@ export function testCropBounce(image: IJS): IJS {
 
   const rgba = derivative.convertColor(ImageColorModel.RGBA);
 
-  return rgba.copyTo(image, { rowOffset: row, columnOffset: column });
+  return rgba.copyTo(image, { row: row, column: column });
 }

--- a/demo/components/testFunctions/testGetBorderPoints.ts
+++ b/demo/components/testFunctions/testGetBorderPoints.ts
@@ -1,7 +1,23 @@
-import { IJS } from '../../../src';
+import { fromMask, IJS, ImageColorModel, Mask } from '../../../src';
+import { RoiKind } from '../../../src/roi/getRois';
 
-export function testGetBorderPixels(image: IJS): IJS {
-  // TODO: implement this demo
+export function testGetBorderPoints(image: IJS): IJS {
+  const grey = image.convertColor(ImageColorModel.GREY);
+  const mask = grey.threshold();
 
-  return image;
+  const roiMapManager = fromMask(mask);
+
+  const rois = roiMapManager.getRois({ kind: RoiKind.BLACK });
+
+  const roi = rois.sort((a, b) => b.surface - a.surface)[0];
+
+  let points = roi.getBorderPoints();
+
+  let borderMask = Mask.fromPoints(roi.width, roi.height, points);
+
+  return image.paintMask(borderMask, {
+    row: roi.row,
+    column: roi.column,
+    color: [0, 255, 0, 255],
+  });
 }

--- a/demo/components/testFunctions/testGetBorderPoints.ts
+++ b/demo/components/testFunctions/testGetBorderPoints.ts
@@ -1,0 +1,7 @@
+import { IJS } from '../../../src';
+
+export function testGetBorderPixels(image: IJS): IJS {
+  // TODO: implement this demo
+
+  return image;
+}

--- a/demo/components/testFunctions/testGetBorderPoints.ts
+++ b/demo/components/testFunctions/testGetBorderPoints.ts
@@ -1,6 +1,10 @@
 import { fromMask, IJS, ImageColorModel, Mask } from '../../../src';
 import { RoiKind } from '../../../src/roi/getRois';
-
+/**
+ * Paint the border of the larger black ROI on the image.
+ * @param image The image to process
+ * @returns The processed image.
+ */
 export function testGetBorderPoints(image: IJS): IJS {
   const grey = image.convertColor(ImageColorModel.GREY);
   const mask = grey.threshold();

--- a/demo/components/testFunctions/testPaintMask.ts
+++ b/demo/components/testFunctions/testPaintMask.ts
@@ -1,0 +1,23 @@
+import { fromMask, IJS, ImageColorModel } from '../../../src';
+import { RoiKind } from '../../../src/roi/getRois';
+
+export function testPaintMask(image: IJS): IJS {
+  const grey = image.convertColor(ImageColorModel.GREY);
+  const mask = grey.threshold({ threshold: 50 });
+
+  const roiMapManager = fromMask(mask);
+
+  const rois = roiMapManager.getRois({ kind: RoiKind.BLACK });
+
+  const biggestRoi = rois.sort((a, b) => b.surface - a.surface)[0];
+
+  const roiMask = biggestRoi.getMask();
+
+  const faded = image.fillAlpha(Math.round(image.maxValue / 2));
+
+  return faded.paintMask(roiMask, {
+    row: biggestRoi.row,
+    column: biggestRoi.column,
+    color: [0, 0, 255, 255],
+  });
+}

--- a/demo/components/testFunctions/testPaintMask.ts
+++ b/demo/components/testFunctions/testPaintMask.ts
@@ -1,9 +1,13 @@
 import { fromMask, IJS, ImageColorModel } from '../../../src';
 import { RoiKind } from '../../../src/roi/getRois';
-
+/**
+ * Make the image translucent, excepted where the largest black ROI is.
+ * @param image Image to process.
+ * @returns Processed image.
+ */
 export function testPaintMask(image: IJS): IJS {
   const grey = image.convertColor(ImageColorModel.GREY);
-  const mask = grey.threshold({ threshold: 50 });
+  const mask = grey.threshold({ threshold: 100 });
 
   const roiMapManager = fromMask(mask);
 
@@ -13,11 +17,12 @@ export function testPaintMask(image: IJS): IJS {
 
   const roiMask = biggestRoi.getMask();
 
-  const faded = image.fillAlpha(Math.round(image.maxValue / 2));
+  const faded = image.fillAlpha(Math.round(image.maxValue / 4));
 
   return faded.paintMask(roiMask, {
     row: biggestRoi.row,
     column: biggestRoi.column,
-    color: [0, 0, 255, 255],
+    blend: false,
+    color: [null, null, null, 255],
   });
 }

--- a/src/IJS.ts
+++ b/src/IJS.ts
@@ -51,6 +51,8 @@ import {
   crop,
   CropOptions,
   grey,
+  paintMask,
+  PaintMaskOptions,
   split,
 } from './operations';
 import { ImageColorModel, colorModels } from './utils/colorModels';
@@ -524,6 +526,17 @@ export class IJS {
    */
   public extract(mask: Mask, options?: ExtractOptions): IJS {
     return extract(this, mask, options);
+  }
+
+  /**
+   * Paint a mask onto an image and the given position and with the given color.
+   *
+   * @param mask - Mask to paint on the image.
+   * @param options - Paint mask options.
+   * @returns The painted image.
+   */
+  public paintMask(mask: Mask, options?: PaintMaskOptions): IJS {
+    return paintMask(this, mask, options);
   }
 
   // FILTERS

--- a/src/IJS.ts
+++ b/src/IJS.ts
@@ -817,25 +817,3 @@ function printData(img: IJS): string {
     ${`[\n     ${result.join('\n     ')}\n    ]`}
   }`;
 }
-
-/**
- * Returns all values of a channel as a string.
- *
- * @param img - Input image.
- * @param channel - Specified channel.
- * @returns Formatted string with all values of a channel.
- */
-function printChannel(img: IJS, channel: number): string {
-  const result = [];
-  const padding = img.depth === 8 ? 3 : 5;
-  for (let row = 0; row < img.height; row++) {
-    const line = [];
-    for (let column = 0; column < img.width; column++) {
-      line.push(
-        String(img.getValue(column, row, channel)).padStart(padding, ' '),
-      );
-    }
-    result.push(`[${line.join(' ')}]`);
-  }
-  return result.join('\n     ');
-}

--- a/src/IJS.ts
+++ b/src/IJS.ts
@@ -798,12 +798,23 @@ function createPixelArray(
  * @returns Formatted string containing the image data.
  */
 function printData(img: IJS): string {
-  const channels = [];
-  for (let c = 0; c < img.channels; c++) {
-    channels.push(`[${printChannel(img, c)}]`);
+  const result = [];
+  const padding = img.depth === 8 ? 3 : 5;
+
+  for (let row = 0; row < img.height; row++) {
+    const currentRow = [];
+    for (let column = 0; column < img.width; column++) {
+      for (let channel = 0; channel < img.channels; channel++) {
+        currentRow.push(
+          String(img.getValue(column, row, channel)).padStart(padding, ' '),
+        );
+      }
+    }
+    result.push(`[${currentRow.join(' ')}]`);
   }
+
   return `{
-    ${channels.join('\n\n    ')}
+    ${`[\n     ${result.join('\n     ')}\n    ]`}
   }`;
 }
 

--- a/src/Mask.ts
+++ b/src/Mask.ts
@@ -33,6 +33,7 @@ import { erode } from './morphology/erode';
 import { boolToNumber } from './utils/boolToNumber';
 
 import { ImageColorModel, ColorDepth, colorModels, IJS, convertColor } from '.';
+import { Point } from './utils/types';
 
 export type BitValue = 1 | 0 | boolean;
 
@@ -162,6 +163,28 @@ export class Mask {
   ): Mask {
     const { width = other.width, height = other.height } = options;
     return new Mask(width, height, options);
+  }
+
+  /**
+   * Create a mask from an array of points.
+   *
+   * @param width - Width of the mask.
+   * @param height - Height of the mask.
+   *  @param points - Reference Mask.
+   * @returns New mask.
+   */
+  public static fromPoints(
+    width: number,
+    height: number,
+    points: Point[],
+  ): Mask {
+    let mask = new Mask(width, height);
+
+    for (const point of points) {
+      mask.setBit(point[0], point[1], 1);
+    }
+
+    return mask;
   }
 
   /**
@@ -335,6 +358,7 @@ export class Mask {
   public subtractImage(other: Mask, options?: SubtractImageOptions): Mask {
     return subtractImage(this, other, options);
   }
+
   /**
    * Perform an AND operation on two masks.
    *

--- a/src/__tests__/IJS.test.ts
+++ b/src/__tests__/IJS.test.ts
@@ -1,6 +1,7 @@
 import { inspect } from 'util';
 
 import { IJS, ColorDepth } from '../IJS';
+import { Mask } from '../Mask';
 import { ImageColorModel } from '../utils/colorModels';
 
 describe('create new images', () => {
@@ -224,7 +225,13 @@ test('fill alpha should throw if no alpha', () => {
   );
 });
 
-test('check custom inspect', () => {
-  const mask = new IJS(1, 2);
-  expect(inspect(mask)).toMatchSnapshot();
+test('check custom inspect, RGB image', () => {
+  const image = new IJS(1, 2);
+
+  expect(inspect(image)).toMatchSnapshot();
+});
+test('check custom inspect, GREYA image', () => {
+  const image = new IJS(2, 2, { colorModel: ImageColorModel.GREYA });
+
+  expect(inspect(image)).toMatchSnapshot();
 });

--- a/src/__tests__/IJS.test.ts
+++ b/src/__tests__/IJS.test.ts
@@ -1,7 +1,6 @@
 import { inspect } from 'util';
 
 import { IJS, ColorDepth } from '../IJS';
-import { Mask } from '../Mask';
 import { ImageColorModel } from '../utils/colorModels';
 
 describe('create new images', () => {

--- a/src/__tests__/Mask.test.ts
+++ b/src/__tests__/Mask.test.ts
@@ -2,6 +2,7 @@ import util from 'util';
 
 import { ColorDepth, ImageColorModel } from '..';
 import { Mask } from '../Mask';
+import { Point } from '../utils/types';
 
 describe('create new masks', () => {
   it('should create a mask', () => {
@@ -93,6 +94,15 @@ test('createFrom', () => {
   const newMask = Mask.createFrom(mask);
   expect(mask.width).toBe(newMask.width);
   expect(mask.height).toBe(newMask.height);
+});
+
+test('fromPoints', () => {
+  const points: Point[] = [[1, 1]];
+  expect(Mask.fromPoints(5, 3, points)).toMatchMaskData([
+    [0, 0, 0, 0, 0],
+    [0, 1, 0, 0, 0],
+    [0, 0, 0, 0, 0],
+  ]);
 });
 
 test('clone', () => {

--- a/src/__tests__/__snapshots__/IJS.test.ts.snap
+++ b/src/__tests__/__snapshots__/IJS.test.ts.snap
@@ -1,6 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`check custom inspect 1`] = `
+exports[`check custom inspect, GREYA image 1`] = `
+"IJS {
+  width: 2
+  height: 2
+  depth: 8
+  colorModel: GREYA
+  channels: 2
+  data: {
+    [
+     [  0 255   0 255]
+     [  0 255   0 255]
+    ]
+  }
+}"
+`;
+
+exports[`check custom inspect, RGB image 1`] = `
 "IJS {
   width: 1
   height: 2
@@ -8,14 +24,10 @@ exports[`check custom inspect 1`] = `
   colorModel: RGB
   channels: 3
   data: {
-    [[  0]
-     [  0]]
-
-    [[  0]
-     [  0]]
-
-    [[  0]
-     [  0]]
+    [
+     [  0   0   0]
+     [  0   0   0]
+    ]
   }
 }"
 `;

--- a/src/operations/__tests__/copyTo.test.ts
+++ b/src/operations/__tests__/copyTo.test.ts
@@ -28,7 +28,7 @@ describe('Copy a source image to a target', () => {
   it('Bigger GREYA image with offset outside target', () => {
     let target = testUtils.createGreyaImage([[100, 0, 200, 0, 150, 0]]);
     let source = testUtils.createGreyaImage([[20, 255]]);
-    const result = source.copyTo(target, { rowOffset: -1 });
+    const result = source.copyTo(target, { row: -1 });
     expect(result).toMatchImageData([[100, 0, 200, 0, 150, 0]]);
   });
   it('GREY image', () => {
@@ -44,7 +44,7 @@ describe('Copy a source image to a target', () => {
       [200, 250],
     ]);
     let source = testUtils.createGreyImage([[20]]);
-    const result = source.copyTo(target, { rowOffset: 1, columnOffset: 1 });
+    const result = source.copyTo(target, { row: 1, column: 1 });
     expect(result).toMatchImageData([
       [100, 150],
       [200, 20],
@@ -55,7 +55,7 @@ describe('Copy a source image to a target', () => {
       [100, 150],
       [200, 250],
     ]);
-    const result = target.copyTo(target, { rowOffset: 1, columnOffset: 1 });
+    const result = target.copyTo(target, { row: 1, column: 1 });
     expect(result).toMatchImageData([
       [100, 150],
       [200, 100],
@@ -77,7 +77,7 @@ describe('Copy a source image to a target', () => {
       [100, 100],
     ]);
     let target = testUtils.createGreyImage([[20]]);
-    const result = source.copyTo(target, { rowOffset: -1, columnOffset: -1 });
+    const result = source.copyTo(target, { row: -1, column: -1 });
     expect(result).toMatchImageData([[250]]);
   });
   it('RGBA images', () => {
@@ -87,7 +87,7 @@ describe('Copy a source image to a target', () => {
       [7, 8, 9, 0],
     ]);
     let source = testUtils.createRgbaImage([[3, 3, 3, 255]]);
-    const result = source.copyTo(target, { rowOffset: 1, columnOffset: 0 });
+    const result = source.copyTo(target, { row: 1, column: 0 });
     expect(result).toMatchImageData([
       [1, 2, 3, 255],
       [3, 3, 3, 255],

--- a/src/operations/__tests__/paintMask.test.ts
+++ b/src/operations/__tests__/paintMask.test.ts
@@ -138,6 +138,26 @@ describe('paintMask', () => {
       [1, 2, 2, 7],
     ]);
   });
+  it('blend = false, change many pixels', () => {
+    const image = testUtils.createGreyaImage([
+      [30, 23, 2, 2],
+      [45, 65, 1, 5],
+      [1, 2, 2, 7],
+    ]);
+    const mask = testUtils.createMask([
+      [1, 1],
+      [0, 1],
+    ]);
+    const result = image.paintMask(mask, {
+      blend: false,
+      color: [0, 100],
+    });
+    expect(result).toMatchImageData([
+      [0, 100, 0, 100],
+      [45, 65, 0, 100],
+      [1, 2, 2, 7],
+    ]);
+  });
   it('test out option', () => {
     const image = testUtils.createGreyImage([
       [30, 23, 2, 2],

--- a/src/operations/__tests__/paintMask.test.ts
+++ b/src/operations/__tests__/paintMask.test.ts
@@ -17,7 +17,7 @@ describe('paintMask', () => {
       [1, 2, 2],
     ]);
   });
-  it.only('3x3 grey image, offset', () => {
+  it('3x3 grey image, offset', () => {
     const image = testUtils.createGreyImage([
       [30, 23, 2],
       [45, 65, 1],
@@ -28,8 +28,6 @@ describe('paintMask', () => {
       [1, 0],
     ]);
     const result = image.paintMask(mask, { column: 1 });
-
-    console.log(result);
 
     expect(result).toMatchImageData([
       [30, 23, 0],
@@ -48,8 +46,6 @@ describe('paintMask', () => {
       [1, 0, 1],
     ]);
     const result = image.paintMask(mask, { column: -1 });
-
-    console.log(result);
 
     expect(result).toMatchImageData([
       [0, 0, 2],
@@ -74,5 +70,16 @@ describe('paintMask', () => {
       [100, 65, 1],
       [1, 2, 2],
     ]);
+  });
+  it('3x3 grey image, transparent source', () => {
+    const image = testUtils.createRgbaImage([
+      [30, 23, 2, 2],
+      [45, 65, 1, 5],
+      [1, 2, 2, 7],
+    ]);
+    const mask = testUtils.createMask([[1]]);
+    const result = image.paintMask(mask, { color: [20, 30, 40, 0] });
+
+    expect(result).toMatchImage(image);
   });
 });

--- a/src/operations/__tests__/paintMask.test.ts
+++ b/src/operations/__tests__/paintMask.test.ts
@@ -82,4 +82,16 @@ describe('paintMask', () => {
 
     expect(result).toMatchImage(image);
   });
+  it('custom color is incompatible with image', () => {
+    const image = testUtils.createRgbaImage([
+      [30, 23, 2, 2],
+      [45, 65, 1, 5],
+      [1, 2, 2, 7],
+    ]);
+    const mask = testUtils.createMask([[1]]);
+
+    expect(() => {
+      image.paintMask(mask, { color: [20] });
+    }).toThrow('paintMask: the given color is not compatible with the image');
+  });
 });

--- a/src/operations/__tests__/paintMask.test.ts
+++ b/src/operations/__tests__/paintMask.test.ts
@@ -1,0 +1,78 @@
+describe('paintMask', () => {
+  it('3x3 grey image, default options', () => {
+    const image = testUtils.createGreyImage([
+      [30, 23, 2],
+      [45, 65, 1],
+      [1, 2, 2],
+    ]);
+    const mask = testUtils.createMask([
+      [0, 1],
+      [1, 0],
+    ]);
+    const result = image.paintMask(mask);
+
+    expect(result).toMatchImageData([
+      [30, 0, 2],
+      [0, 65, 1],
+      [1, 2, 2],
+    ]);
+  });
+  it.only('3x3 grey image, offset', () => {
+    const image = testUtils.createGreyImage([
+      [30, 23, 2],
+      [45, 65, 1],
+      [1, 2, 2],
+    ]);
+    const mask = testUtils.createMask([
+      [0, 1],
+      [1, 0],
+    ]);
+    const result = image.paintMask(mask, { column: 1 });
+
+    console.log(result);
+
+    expect(result).toMatchImageData([
+      [30, 23, 0],
+      [45, 0, 1],
+      [1, 2, 2],
+    ]);
+  });
+  it('3x3 grey image, negative offset', () => {
+    const image = testUtils.createGreyImage([
+      [30, 23, 2],
+      [45, 65, 1],
+      [1, 2, 2],
+    ]);
+    const mask = testUtils.createMask([
+      [0, 1, 1],
+      [1, 0, 1],
+    ]);
+    const result = image.paintMask(mask, { column: -1 });
+
+    console.log(result);
+
+    expect(result).toMatchImageData([
+      [0, 0, 2],
+      [45, 0, 1],
+      [1, 2, 2],
+    ]);
+  });
+  it('3x3 grey image, custom color', () => {
+    const image = testUtils.createGreyImage([
+      [30, 23, 2],
+      [45, 65, 1],
+      [1, 2, 2],
+    ]);
+    const mask = testUtils.createMask([
+      [1, 1],
+      [1, 0],
+    ]);
+    const result = image.paintMask(mask, { color: [100] });
+
+    expect(result).toMatchImageData([
+      [100, 100, 2],
+      [100, 65, 1],
+      [1, 2, 2],
+    ]);
+  });
+});

--- a/src/operations/__tests__/paintMask.test.ts
+++ b/src/operations/__tests__/paintMask.test.ts
@@ -94,4 +94,65 @@ describe('paintMask', () => {
       image.paintMask(mask, { color: [20] });
     }).toThrow('paintMask: the given color is not compatible with the image');
   });
+  it('blend is true but color has null values', () => {
+    const image = testUtils.createRgbaImage([
+      [30, 23, 2, 2],
+      [45, 65, 1, 5],
+      [1, 2, 2, 7],
+    ]);
+    const mask = testUtils.createMask([[1]]);
+
+    expect(() => {
+      image.paintMask(mask, { color: [null, 0, 0, 255] });
+    }).toThrow(
+      'paintMask: cannot have null channels in color if blend is true',
+    );
+  });
+  it('blend = false, all values null', () => {
+    const image = testUtils.createRgbaImage([
+      [30, 23, 2, 2],
+      [45, 65, 1, 5],
+      [1, 2, 2, 7],
+    ]);
+    const mask = testUtils.createMask([[1]]);
+    const result = image.paintMask(mask, {
+      blend: false,
+      color: [null, null, null, null],
+    });
+    expect(result).toStrictEqual(image);
+  });
+  it('blend = false, change red and alpha', () => {
+    const image = testUtils.createRgbaImage([
+      [30, 23, 2, 2],
+      [45, 65, 1, 5],
+      [1, 2, 2, 7],
+    ]);
+    const mask = testUtils.createMask([[1]]);
+    const result = image.paintMask(mask, {
+      blend: false,
+      color: [255, null, null, 255],
+    });
+    expect(result).toMatchImageData([
+      [255, 23, 2, 255],
+      [45, 65, 1, 5],
+      [1, 2, 2, 7],
+    ]);
+  });
+  it('test out option', () => {
+    const image = testUtils.createGreyImage([
+      [30, 23, 2, 2],
+      [45, 65, 1, 5],
+      [1, 2, 2, 7],
+    ]);
+    const mask = testUtils.createMask([[1]]);
+    image.paintMask(mask, {
+      color: [255],
+      out: image,
+    });
+    expect(image).toMatchImageData([
+      [255, 23, 2, 2],
+      [45, 65, 1, 5],
+      [1, 2, 2, 7],
+    ]);
+  });
 });

--- a/src/operations/copyTo.ts
+++ b/src/operations/copyTo.ts
@@ -8,13 +8,13 @@ export interface CopyToOptions {
    *
    * @default 0
    */
-  columnOffset?: number;
+  column?: number;
   /**
    * Y offset for the copy, the top left corner of the target image is the reference.
    *
    * @default 0
    */
-  rowOffset?: number;
+  row?: number;
   /**
    * Image to which to output.
    */
@@ -34,7 +34,7 @@ export function copyTo(
   target: IJS,
   options: CopyToOptions = {},
 ): IJS {
-  const { columnOffset = 0, rowOffset = 0 } = options;
+  const { column = 0, row = 0 } = options;
 
   if (source.colorModel !== target.colorModel) {
     throw new Error('Source and target should have the same color model.');
@@ -43,17 +43,22 @@ export function copyTo(
   const result = getOutputImage(target, options, { clone: true });
 
   for (
-    let row = Math.max(rowOffset, 0);
-    row < Math.min(source.height + rowOffset, target.height);
-    row++
+    let currentRow = Math.max(row, 0);
+    currentRow < Math.min(source.height + row, target.height);
+    currentRow++
   ) {
     for (
-      let column = Math.max(columnOffset, 0);
-      column < Math.min(source.width + columnOffset, target.width);
-      column++
+      let currentColumn = Math.max(column, 0);
+      currentColumn < Math.min(source.width + column, target.width);
+      currentColumn++
     ) {
-      let sourcePixel = source.getPixel(column - columnOffset, row - rowOffset);
-      setBlendedPixel(result, column, row, { color: sourcePixel });
+      let sourcePixel = source.getPixel(
+        currentColumn - column,
+        currentRow - row,
+      );
+      setBlendedPixel(result, currentColumn, currentRow, {
+        color: sourcePixel,
+      });
     }
   }
 

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -7,3 +7,4 @@ export * from './threshold';
 export * from './grey';
 export * from './copyTo';
 export * from './crop';
+export * from './paintMask';

--- a/src/operations/paintMask.ts
+++ b/src/operations/paintMask.ts
@@ -1,0 +1,74 @@
+import { IJS } from '../IJS';
+import { Mask } from '../Mask';
+import { getDefaultColor } from '../utils/getDefaultColor';
+import { getOutputImage } from '../utils/getOutputImage';
+import { setBlendedPixel } from '../utils/setBlendedPixel';
+
+export interface PaintMaskOptions {
+  /**
+   * X offset for the copy, the top left corner of the target image is the reference.
+   *
+   * @default 0
+   */
+  column?: number;
+  /**
+   * Y offset for the copy, the top left corner of the target image is the reference.
+   *
+   * @default 0
+   */
+  row?: number;
+  /**
+   * Color with which to blend the image pixel.
+   *
+   * @default Opaque black.
+   */
+  color?: number[];
+  /**
+   * Image to which to output.
+   */
+  out?: IJS;
+}
+
+/**
+ * Paint a mask onto an image and the given position and with the given color.
+ *
+ * @param image - Image on which to paint the mask.
+ * @param mask - Mask to paint on the image.
+ * @param options - Paint mask options.
+ * @returns The painted image.
+ */
+export function paintMask(
+  image: IJS,
+  mask: Mask,
+  options: PaintMaskOptions = {},
+): IJS {
+  const { column = 0, row = 0, color = getDefaultColor(image) } = options;
+
+  if (color.length !== image.channels) {
+    throw new Error(
+      'paintMask: the given color is not compatible with the image',
+    );
+  }
+
+  const result = getOutputImage(image, options, { clone: true });
+
+  for (
+    let currentRow = Math.max(row, 0);
+    currentRow < Math.min(mask.height + row, image.height);
+    currentRow++
+  ) {
+    for (
+      let currentColumn = Math.max(column, 0);
+      currentColumn < Math.min(mask.width + column, image.width);
+      currentColumn++
+    ) {
+      if (mask.getBit(currentColumn, currentRow)) {
+        setBlendedPixel(result, currentColumn, currentRow, {
+          color,
+        });
+      }
+    }
+  }
+
+  return result;
+}

--- a/src/operations/paintMask.ts
+++ b/src/operations/paintMask.ts
@@ -97,7 +97,7 @@ export function paintMask(
           for (let channel = 0; channel < image.channels; channel++) {
             const currentValue = color[channel];
             if (typeof currentValue === 'number') {
-              result.setValue(row, column, channel, currentValue);
+              result.setValue(currentColumn, currentRow, channel, currentValue);
             }
           }
         }

--- a/src/operations/paintMask.ts
+++ b/src/operations/paintMask.ts
@@ -62,7 +62,7 @@ export function paintMask(
       currentColumn < Math.min(mask.width + column, image.width);
       currentColumn++
     ) {
-      if (mask.getBit(currentColumn, currentRow)) {
+      if (mask.getBit(currentColumn - column, currentRow - row)) {
         setBlendedPixel(result, currentColumn, currentRow, {
           color,
         });

--- a/src/roi/Roi.ts
+++ b/src/roi/Roi.ts
@@ -1,6 +1,8 @@
 import { Mask } from '../Mask';
+import { Point } from '../utils/types';
 
 import { RoiMap } from './RoiMapManager';
+import { GetBorderPointOptions, getBorderPoints } from './getBorderPoints';
 import { getMask } from './getMask';
 
 export class Roi {
@@ -58,5 +60,16 @@ export class Roi {
    */
   public getMask(): Mask {
     return getMask(this);
+  }
+
+  /**
+   * Return an array with the coordinates of the pixels that are on the border of the ROI.
+   * The points are defined as [column, row].
+   *
+   * @param options - Get border points options.
+   * @returns The array of border pixels.
+   */
+  public getBorderPoints(options?: GetBorderPointOptions): Array<Point> {
+    return getBorderPoints(this, options);
   }
 }

--- a/src/roi/__tests__/getBorderPoints.test.ts
+++ b/src/roi/__tests__/getBorderPoints.test.ts
@@ -1,0 +1,118 @@
+import { Mask } from '../../Mask';
+import { fromMask } from '../fromMask';
+import { RoiKind } from '../getRois';
+
+describe('getBorderPoints', () => {
+  it('3x3 mask', () => {
+    const mask = testUtils.createMask([
+      [0, 1, 0],
+      [1, 1, 1],
+      [0, 1, 0],
+    ]);
+    const roiMapManager = fromMask(mask);
+
+    const rois = roiMapManager.getRois({ kind: RoiKind.WHITE });
+    const roi = rois[0];
+
+    let points = roi.getBorderPoints();
+
+    let bordersMask = Mask.fromPoints(roi.width, roi.height, points);
+
+    expect(bordersMask).toMatchMaskData([
+      [0, 1, 0],
+      [1, 0, 1],
+      [0, 1, 0],
+    ]);
+  });
+  it('6x5 mask with hole, no inner borders', () => {
+    const mask = testUtils.createMask([
+      [0, 0, 0, 0, 0],
+      [1, 1, 1, 1, 1],
+      [0, 1, 0, 1, 0],
+      [0, 1, 1, 1, 0],
+      [0, 1, 1, 1, 1],
+      [0, 0, 0, 0, 0],
+    ]);
+    const roiMapManager = fromMask(mask);
+
+    const rois = roiMapManager.getRois({ kind: RoiKind.WHITE });
+    const roi = rois[0];
+
+    let points = roi.getBorderPoints();
+
+    let bordersMask = Mask.fromPoints(roi.width, roi.height, points);
+
+    expect(bordersMask).toMatchMaskData([
+      [1, 1, 1, 1, 1],
+      [0, 1, 0, 1, 0],
+      [0, 1, 0, 1, 0],
+      [0, 1, 1, 1, 1],
+    ]);
+  });
+  it('5x5 mask with hole, inner borders, allow corners', () => {
+    const mask = testUtils.createMask([
+      [1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1],
+      [1, 1, 0, 1, 1],
+      [1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1],
+    ]);
+    const roiMapManager = fromMask(mask);
+
+    const rois = roiMapManager.getRois({ kind: RoiKind.WHITE });
+    const roi = rois[0];
+
+    let points = roi.getBorderPoints({
+      innerBorders: true,
+      allowCorners: true,
+    });
+
+    let bordersMask = Mask.fromPoints(roi.width, roi.height, points);
+
+    expect(bordersMask).toMatchMask(mask);
+  });
+  it('6x5 mask with hole, inner borders', () => {
+    const mask = testUtils.createMask([
+      [1, 0, 0, 0, 0],
+      [1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 0],
+      [1, 0, 1, 1, 0],
+      [1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 0],
+    ]);
+    const roiMapManager = fromMask(mask);
+
+    const rois = roiMapManager.getRois({ kind: RoiKind.WHITE });
+    const roi = rois[0];
+
+    let points = roi.getBorderPoints({ innerBorders: true });
+
+    let bordersMask = Mask.fromPoints(roi.width, roi.height, points);
+
+    expect(bordersMask).toMatchMaskData([
+      [1, 0, 0, 0, 0],
+      [1, 1, 1, 1, 1],
+      [1, 1, 0, 1, 0],
+      [1, 0, 1, 1, 0],
+      [1, 1, 0, 0, 1],
+      [1, 1, 1, 1, 0],
+    ]);
+  });
+  it('6x5 mask with hole, allowCorners', () => {
+    const mask = testUtils.createMask([
+      [0, 1, 0],
+      [1, 1, 1],
+      [0, 1, 0],
+    ]);
+    const roiMapManager = fromMask(mask);
+
+    const rois = roiMapManager.getRois({ kind: RoiKind.WHITE });
+    const roi = rois[0];
+
+    let points = roi.getBorderPoints({ allowCorners: true });
+
+    let bordersMask = Mask.fromPoints(roi.width, roi.height, points);
+
+    expect(bordersMask).toMatchMask(mask);
+  });
+});

--- a/src/roi/getBorderPoints.ts
+++ b/src/roi/getBorderPoints.ts
@@ -1,0 +1,82 @@
+import { Point } from '../utils/types';
+
+import { Roi } from './Roi';
+
+export interface GetBorderPointOptions {
+  /**
+   * Should the inner borders be returned too?
+   *
+   * @default false
+   */
+  innerBorders?: boolean;
+
+  allowCorners?: boolean;
+}
+
+// TODO: This function could be optimised by following the contour instead of scanning all pixels.
+/**
+ * Return an array with the coordinates of the pixels that are on the border of the ROI.
+ * The points are defined as [column, row].
+ *
+ * @param roi - ROI to process.
+ * @param options - Get border points options.
+ * @returns The array of border pixels.
+ */
+export function getBorderPoints(
+  roi: Roi,
+  options: GetBorderPointOptions = {},
+): Array<Point> {
+  const { innerBorders = false, allowCorners = false } = options;
+  const mask = roi.getMask();
+  if (!innerBorders) {
+    mask.solidFill({ out: mask });
+  }
+
+  let borders: Array<Point> = [];
+
+  // first process frame pixels
+  for (let column = 0; column < mask.width; column++) {
+    if (mask.getBit(column, 0)) {
+      borders.push([column, 0]);
+    }
+    if (mask.getBit(column, mask.height - 1)) {
+      borders.push([column, mask.height - 1]);
+    }
+  }
+  for (let row = 0; row < mask.height; row++) {
+    if (mask.getBit(0, row)) {
+      borders.push([0, row]);
+    }
+    if (mask.getBit(mask.width - 1, row)) {
+      borders.push([mask.width - 1, row]);
+    }
+  }
+
+  for (let row = 1; row < mask.height - 1; row++) {
+    for (let column = 1; column < mask.width - 1; column++) {
+      if (mask.getBit(column, row)) {
+        if (
+          mask.getBit(column - 1, row) === 0 ||
+          mask.getBit(column, row - 1) === 0 ||
+          mask.getBit(column + 1, row) === 0 ||
+          mask.getBit(column, row + 1) === 0
+        ) {
+          borders.push([column, row]);
+        }
+
+        if (allowCorners) {
+          if (
+            mask.getBit(column - 1, row - 1) === 0 ||
+            mask.getBit(column - 1, row + 1) === 0 ||
+            mask.getBit(column + 1, row - 1) === 0 ||
+            mask.getBit(column + 1, row + 1) === 0
+          ) {
+            borders.push([column, row]);
+          }
+        }
+      }
+    }
+  }
+
+  return borders;
+}

--- a/src/utils/__tests__/setBlendedPixel.test.ts
+++ b/src/utils/__tests__/setBlendedPixel.test.ts
@@ -1,0 +1,32 @@
+import { setBlendedPixel } from '../setBlendedPixel';
+
+describe('setBlendedPixel', () => {
+  it('GREYA image, default options', () => {
+    let image = testUtils.createGreyaImage([
+      [50, 255],
+      [20, 30],
+    ]);
+    setBlendedPixel(image, 0, 1);
+    expect(image).toMatchImageData([
+      [50, 255],
+      [0, 255],
+    ]);
+  });
+  it('GREYA images: transparent source, opaque target', () => {
+    let image = testUtils.createGreyaImage([[50, 255]]);
+    setBlendedPixel(image, 0, 0, { color: [100, 0] });
+    expect(image).toMatchImageData([[50, 255]]);
+  });
+  it('GREYA images: opaque source, transparent target', () => {
+    let image = testUtils.createGreyaImage([[50, 0]]);
+    setBlendedPixel(image, 0, 0, { color: [100, 255] });
+    expect(image).toMatchImageData([[100, 255]]);
+  });
+  it('GREYA image: alpha different from 255', () => {
+    let image = testUtils.createGreyaImage([[50, 64]]);
+    setBlendedPixel(image, 0, 0, { color: [100, 128] });
+    const alpha = 128 + 64 * (1 - 128 / 255);
+    const component = (100 * 128 + 50 * 64 * (1 - 128 / 255)) / alpha;
+    expect(image).toMatchImageData([[component, alpha]]);
+  });
+});

--- a/src/utils/__tests__/setBlendedPixel.test.ts
+++ b/src/utils/__tests__/setBlendedPixel.test.ts
@@ -29,4 +29,17 @@ describe('setBlendedPixel', () => {
     const component = (100 * 128 + 50 * 64 * (1 - 128 / 255)) / alpha;
     expect(image).toMatchImageData([[component, alpha]]);
   });
+  it('asymetrical test', () => {
+    let image = testUtils.createGreyaImage([
+      [50, 255, 1, 2, 3, 4],
+      [20, 30, 5, 6, 7, 8],
+      [1, 2, 3, 4, 5, 6],
+    ]);
+    setBlendedPixel(image, 2, 0, { color: [0, 125] });
+    expect(image).toMatchImageData([
+      [50, 255, 1, 2, 0, 127],
+      [20, 30, 5, 6, 7, 8],
+      [1, 2, 3, 4, 5, 6],
+    ]);
+  });
 });

--- a/src/utils/setBlendedPixel.ts
+++ b/src/utils/setBlendedPixel.ts
@@ -1,0 +1,55 @@
+import { IJS } from '../IJS';
+
+import { getDefaultColor } from './getDefaultColor';
+
+export interface SetBlendedPixelOptions {
+  color?: number[];
+}
+
+/**
+ * Blend the given pixel with the pixel at the specified location in the image.
+ *
+ * @param image - The image with which to blend.
+ * @param column - Column of the target pixel.
+ * @param row - Row of the target pixel.
+ * @param options - Set blended pixel options.
+ */
+export function setBlendedPixel(
+  image: IJS,
+  column: number,
+  row: number,
+  options: SetBlendedPixelOptions = {},
+) {
+  const { color = getDefaultColor(image) } = options;
+
+  if (!image.alpha) {
+    image.setPixel(column, row, color);
+    return;
+  } else {
+    const sourceAlpha = color[color.length - 1];
+
+    if (sourceAlpha === image.maxValue) {
+      image.setPixel(column, row, color);
+      return;
+    }
+
+    const targetAlpha = image.getValue(column, row, image.channels - 1);
+
+    let newAlpha =
+      sourceAlpha + targetAlpha * (1 - sourceAlpha / image.maxValue);
+
+    image.setValue(row, column, image.channels - 1, newAlpha);
+
+    for (let component = 0; component < image.components; component++) {
+      let sourceComponent = color[component];
+      let targetComponent = image.getValue(row, column, component);
+
+      let newComponent =
+        (sourceComponent * sourceAlpha +
+          targetComponent * targetAlpha * (1 - sourceAlpha / image.maxValue)) /
+        newAlpha;
+
+      image.setValue(row, column, component, newComponent);
+    }
+  }
+}

--- a/src/utils/setBlendedPixel.ts
+++ b/src/utils/setBlendedPixel.ts
@@ -43,18 +43,18 @@ export function setBlendedPixel(
     let newAlpha =
       sourceAlpha + targetAlpha * (1 - sourceAlpha / image.maxValue);
 
-    image.setValue(row, column, image.channels - 1, newAlpha);
+    image.setValue(column, row, image.channels - 1, newAlpha);
 
     for (let component = 0; component < image.components; component++) {
       let sourceComponent = color[component];
-      let targetComponent = image.getValue(row, column, component);
+      let targetComponent = image.getValue(column, row, component);
 
       let newComponent =
         (sourceComponent * sourceAlpha +
           targetComponent * targetAlpha * (1 - sourceAlpha / image.maxValue)) /
         newAlpha;
 
-      image.setValue(row, column, component, newComponent);
+      image.setValue(column, row, component, newComponent);
     }
   }
 }

--- a/src/utils/setBlendedPixel.ts
+++ b/src/utils/setBlendedPixel.ts
@@ -3,6 +3,11 @@ import { IJS } from '../IJS';
 import { getDefaultColor } from './getDefaultColor';
 
 export interface SetBlendedPixelOptions {
+  /**
+   * Color with which to blend the image pixel.
+   *
+   * @default Opaque black.
+   */
   color?: number[];
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,1 @@
+export type Point = [column: number, row: number];


### PR DESCRIPTION
- feat: implement Mask.fromPoints
- feat: implement getBorderPoints (close #78)
- feat: implement setBlendedPixel (close #88)
- fix(copyTo): use setBlendedPixel
- refactor(copyTo): change options to be consistant
- demo: start border points demo
- feat: implement paintMask (close #95)
- fix(paintMask): error in row and column
- test(paintMask): enhance coverage
- fix(setBlendedPixel): some rows and columns were inverted
- test(setBlendedPixel): asymetrical test
- docs(demo): getBorderPoints demo
- docs(demo): paintMask demo
- fix: custom inspect was false (close #31)
- chore: remove useless lines
- feat(paintMask): implement blend option
- fix(paintMask): fix bug with blend false
- docs(demo): paintMask demo
