### PR TITLE
feat: implement drawCircle using bresenham-zingl

### DIFF
--- a/src/draw/__tests__/drawCircleOnIjs.test.ts
+++ b/src/draw/__tests__/drawCircleOnIjs.test.ts
@@ -101,6 +101,44 @@ describe('we check drawCircle', () => {
     ]);
     expect(expected).not.toBe(image);
   });
+  it('draw grey filled circle, radius=0', () => {
+    const image = testUtils.createGreyImage([
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+    ]);
+    const center = { row: 1, column: 1 };
+    const radius = 0;
+    const expected = image.drawCircle(center, radius, {
+      color: [1],
+      fill: [2],
+    });
+    expect(expected).toMatchImageData([
+      [0, 0, 0],
+      [0, 1, 0],
+      [0, 0, 0],
+    ]);
+    expect(expected).not.toBe(image);
+  });
+  it('draw grey filled circle, radius=1', () => {
+    const image = testUtils.createGreyImage([
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+    ]);
+    const center = { row: 1, column: 1 };
+    const radius = 1;
+    const expected = image.drawCircle(center, radius, {
+      color: [1],
+      fill: [2],
+    });
+    expect(expected).toMatchImageData([
+      [0, 1, 0],
+      [1, 2, 1],
+      [0, 1, 0],
+    ]);
+    expect(expected).not.toBe(image);
+  });
   it('draw grey filled circle', () => {
     const image = testUtils.createGreyImage([
       [0, 0, 0, 0, 0, 0],
@@ -124,7 +162,41 @@ describe('we check drawCircle', () => {
     ]);
     expect(expected).not.toBe(image);
   });
-  it('big image test', () => {
+  it('big image not filled', () => {
+    const image = testUtils.createGreyImage([
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    ]);
+    const center = { row: 5, column: 6 };
+    const radius = 4;
+    const expected = image.drawCircle(center, radius, {
+      color: [1],
+    });
+    expect(expected).toMatchImageData([
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0],
+      [0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0],
+      [0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0],
+      [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0],
+      [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0],
+      [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0],
+      [0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0],
+      [0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0],
+      [0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    ]);
+    expect(expected).not.toBe(image);
+  });
+  it('big image filled', () => {
     const image = testUtils.createGreyImage([
       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/src/draw/__tests__/drawCircleOnIjs.test.ts
+++ b/src/draw/__tests__/drawCircleOnIjs.test.ts
@@ -101,6 +101,20 @@ describe('we check drawCircle', () => {
     ]);
     expect(expected).not.toBe(image);
   });
+  it('circle with radius<0', () => {
+    const image = testUtils.createGreyImage([
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+    ]);
+    const center = { row: 1, column: 1 };
+    const radius = -1;
+    expect(() => {
+      image.drawCircle(center, radius, {
+        color: [1],
+      });
+    }).toThrow('Circle radius must be positive');
+  });
   it('draw grey filled circle, radius=0', () => {
     const image = testUtils.createGreyImage([
       [0, 0, 0],

--- a/src/draw/drawCircleOnIjs.ts
+++ b/src/draw/drawCircleOnIjs.ts
@@ -1,3 +1,5 @@
+import { circle } from 'bresenham-zingl';
+
 import { IJS } from '../IJS';
 import checkProcessable from '../utils/checkProcessable';
 import { getDefaultColor } from '../utils/getDefaultColor';
@@ -43,71 +45,44 @@ export function drawCircleOnIjs(
 ): IJS {
   const newImage = getOutputImage(image, options, { clone: true });
   const { color = getDefaultColor(newImage), fill } = options;
-  const { row: cRow, column: cColumn } = center;
   checkProcessable(newImage, 'paintPoints', {
     bitDepth: [8, 16],
   });
 
-  /**
-   *
-   * Draw all other 7 pixels
-   * Present at symmetric position
-   *
-   * @param column - Position column.
-   * @param row - Position row.
-   */
-  function drawCircle(column: number, row: number) {
-    newImage.setPixel(column + cColumn, row + cRow, color);
-    newImage.setPixel(row + cColumn, column + cRow, color);
-    newImage.setPixel(-row + cColumn, column + cRow, color);
-    newImage.setPixel(column + cColumn, -row + cRow, color);
-    // if (column !== 0) {
-    newImage.setPixel(-column + cColumn, row + cRow, color);
-    newImage.setPixel(row + cColumn, -column + cRow, color);
-    newImage.setPixel(-row + cColumn, -column + cRow, color);
-    newImage.setPixel(-column + cColumn, -row + cRow, color);
-    // }
-    if (fill) {
-      fillCircle(column, row);
-    }
+  if (radius < 0) {
+    throw Error('circle radius must be positive');
+  }
+  if (radius === 0) {
+    newImage.setPixel(center.column, center.row, color);
+    return newImage;
   }
 
-  /**
-   *
-   * Fill circle symmetrically
-   *
-   * @param column - Point column.
-   * @param row - Point row.
-   */
-  function fillCircle(column: number, row: number) {
-    if (fill) {
-      for (let i = column; i < row; i++) {
-        newImage.setPixel(column + cColumn, i + cRow, fill);
-        newImage.setPixel(column + cColumn, -i + cRow, fill);
-        newImage.setPixel(i + cColumn, column + cRow, fill);
-        newImage.setPixel(-i + cColumn, column + cRow, fill);
-        // if (column !== 0) {
-        newImage.setPixel(-column + cColumn, i + cRow, fill);
-        newImage.setPixel(-column + cColumn, -i + cRow, fill);
-        newImage.setPixel(i + cColumn, -column + cRow, fill);
-        newImage.setPixel(-i + cColumn, -column + cRow, fill);
-        // }
+  if (!fill) {
+    circle(center.column, center.row, radius, (column: number, row: number) => {
+      newImage.setPixel(column, row, color);
+    });
+  } else {
+    if (radius === 1) {
+      newImage.setPixel(center.column, center.row, fill);
+    }
+    circle(center.column, center.row, radius, (column: number, row: number) => {
+      newImage.setPixel(column, row, color);
+
+      //todo: fill is not optimal we can fill symetrically
+      if (column - 1 > center.column) {
+        newImage.drawLine(
+          { row, column: column - 1 },
+          { row, column: center.column },
+          { strokeColor: fill, out: newImage },
+        );
+      } else if (column + 1 < center.column) {
+        newImage.drawLine(
+          { row, column: column + 1 },
+          { row, column: center.column },
+          { strokeColor: fill, out: newImage },
+        );
       }
-    }
-  }
-  let column = 0;
-  let row = radius;
-  let d = 3 - 2 * radius;
-  drawCircle(column, row);
-  while (row >= column) {
-    column++;
-    if (d > 0) {
-      row--;
-      d = d + 4 * (column - row) + 10;
-    } else {
-      d = d + 4 * column + 6;
-    }
-    drawCircle(column, row);
+    });
   }
 
   return newImage;

--- a/src/draw/drawCircleOnIjs.ts
+++ b/src/draw/drawCircleOnIjs.ts
@@ -50,7 +50,7 @@ export function drawCircleOnIjs(
   });
 
   if (radius < 0) {
-    throw Error('circle radius must be positive');
+    throw new Error('Circle radius must be positive');
   }
   if (radius === 0) {
     newImage.setPixel(center.column, center.row, color);
@@ -68,7 +68,7 @@ export function drawCircleOnIjs(
     circle(center.column, center.row, radius, (column: number, row: number) => {
       newImage.setPixel(column, row, color);
 
-      //todo: fill is not optimal we can fill symetrically
+      //todo: fill is not optimal we can fill symmetrically
       if (column - 1 > center.column) {
         newImage.drawLine(
           { row, column: column - 1 },

--- a/src/types/bresenham-zingl.d.ts
+++ b/src/types/bresenham-zingl.d.ts
@@ -1,6 +1,16 @@
 declare module 'bresenham-zingl' {
   type SetPixel = (x: number, y: number) => void;
   type SetPixelAlpha = (x: number, y: number, alpha: number) => void;
+
+  /**
+   * Line segment rasterisation
+   *
+   * @param x0 - Starting point x coordinate.
+   * @param y0 - Starting point y coordinate.
+   * @param x1 - Ending point x coordinate.
+   * @param y1 - Ending point y coordinate.
+   * @param setPixel - Function to set a pixel.
+   */
   export function line(
     x0: number,
     y0: number,
@@ -9,11 +19,35 @@ declare module 'bresenham-zingl' {
     setPixel: SetPixel,
   ): void;
 
+  /**
+   * Draw anti-aliased line
+   *
+   * @param x0 - Starting point x coordinate.
+   * @param y0 - Starting point y coordinate.
+   * @param x1 - Ending point x coordinate.
+   * @param y1 - Ending point y coordinate.
+   * @param setPixel - Function to set a pixel with alpha.
+   */
   export function lineAA(
     x0: number,
     y0: number,
     x1: number,
     y1: number,
     setPixel: SetPixelAlpha,
+  ): void;
+
+  /**
+   * Circle rasterisation
+   *
+   * @param xm - Circle center x
+   * @param ym - Circle center y
+   * @param r - Circle radius
+   * @param setPixel - Set pixel function
+   */
+  export function circle(
+    xm: number,
+    ym: number,
+    r: number,
+    setPixel: SetPixel,
   ): void;
 }


### PR DESCRIPTION
after merging https://github.com/image-js/image-js-typescript/pull/124 (same point line case) tests will run correctly

also i think filling the circle can be optimized, if we do it symmetrically

another point
the library is using 4 symetric points to draw the circle, and in the previous algo i used 8 points 
![image](https://user-images.githubusercontent.com/56769876/177177985-08bd0359-e562-4293-9290-a792e3018f70.png)
