### PR TITLE
Use `origin` in `copyTo` and `floodFill`

### DIFF
--- a/demo/components/testFunctions/testCopyTo.ts
+++ b/demo/components/testFunctions/testCopyTo.ts
@@ -8,20 +8,26 @@ import { IJS, ImageColorModel } from '../../../src';
  */
 export function testCopyTo(image: IJS): IJS {
   let result = image.copyTo(image, {
-    row: image.height / 2,
-    column: image.width / 2,
+    origin: {
+      row: image.height / 2,
+      column: image.width / 2,
+    },
   });
   let blackSquare = new IJS(50, 50, { colorModel: ImageColorModel.RGBA });
   let redSquare = new IJS(150, 150, { colorModel: ImageColorModel.RGBA });
   redSquare.fillChannel(0, 255);
   redSquare.fillAlpha(100);
   result = blackSquare.copyTo(result, {
-    row: 200,
-    column: 300,
+    origin: {
+      row: 200,
+      column: 300,
+    },
   });
   redSquare.copyTo(result, {
-    column: ((Date.now() / 10) >>> 0) % 500,
-    row: ((Date.now() / 10) >>> 0) % 500,
+    origin: {
+      column: ((Date.now() / 10) >>> 0) % 500,
+      row: ((Date.now() / 10) >>> 0) % 500,
+    },
     out: result,
   });
   return result;

--- a/demo/components/testFunctions/testCrop.ts
+++ b/demo/components/testFunctions/testCrop.ts
@@ -41,5 +41,5 @@ export function testCropBounce(image: IJS): IJS {
 
   const rgba = derivative.convertColor(ImageColorModel.RGBA);
 
-  return rgba.copyTo(image, { row, column });
+  return rgba.copyTo(image, { origin: { row, column } });
 }

--- a/src/morphology/__tests__/floodFill.test.ts
+++ b/src/morphology/__tests__/floodFill.test.ts
@@ -27,7 +27,7 @@ describe('floodFill', () => {
       [0, 0, 0, 0, 0],
     ]);
 
-    expect(image.floodFill({ row: 0, column: 3 })).toMatchMaskData([
+    expect(image.floodFill({ origin: { row: 0, column: 3 } })).toMatchMaskData([
       [1, 1, 1, 1, 1],
       [1, 1, 1, 1, 1],
       [0, 0, 0, 0, 0],
@@ -62,7 +62,7 @@ describe('floodFill', () => {
     ]);
 
     expect(
-      image.floodFill({ row: 1, column: 1, allowCorners: true }),
+      image.floodFill({ origin: { row: 1, column: 1 }, allowCorners: true }),
     ).toMatchMaskData([
       [1, 1, 1, 1, 1],
       [1, 1, 1, 1, 1],
@@ -87,7 +87,7 @@ describe('floodFill', () => {
 
     const out = new Mask(5, 5);
 
-    image.floodFill({ row: 2, column: 2, out });
+    image.floodFill({ origin: { row: 2, column: 2 }, out });
 
     expect(out).toMatchMaskData([
       [0, 0, 0, 0, 0],

--- a/src/morphology/floodFill.ts
+++ b/src/morphology/floodFill.ts
@@ -1,21 +1,15 @@
-import { Mask } from '..';
+import { Mask, Point } from '..';
 import { getIndex } from '../utils/getIndex';
 
 import { multipleFloodFill } from './multipleFloodFill';
 
 export interface FloodFillOptions {
   /**
-   * Row coordinate of the starting point for the algorithm.
+   * Origin for the algorithm relative to the top-left corner of the image.
    *
-   * @default 0
+   * @default {row: 0, column: 0}
    */
-  row?: number;
-  /**
-   * Column coordinate of the starting point for the algorithm.
-   *
-   * @default 0
-   */
-  column?: number;
+  origin?: Point;
   /**
    * Consider pixels connected by corners?
    *
@@ -36,8 +30,8 @@ export interface FloodFillOptions {
  * @returns The filled mask.
  */
 export function floodFill(mask: Mask, options: FloodFillOptions = {}): Mask {
-  let { row = 0, column = 0, allowCorners = false, out } = options;
-  const startPixel = getIndex(column, row, mask);
+  let { origin = { row: 0, column: 0 }, allowCorners = false, out } = options;
+  const startPixel = getIndex(origin.column, origin.row, mask);
   return multipleFloodFill(mask, {
     startPixels: [startPixel],
     allowCorners,

--- a/src/operations/__tests__/copyTo.test.ts
+++ b/src/operations/__tests__/copyTo.test.ts
@@ -37,7 +37,7 @@ describe('Copy a source image to a target', () => {
   it('Bigger GREYA image with offset outside target', () => {
     let target = testUtils.createGreyaImage([[100, 0, 200, 0, 150, 0]]);
     let source = testUtils.createGreyaImage([[20, 255]]);
-    const result = source.copyTo(target, { row: -1 });
+    const result = source.copyTo(target, { origin: { row: -1, column: 0 } });
     expect(result).toMatchImageData([[100, 0, 200, 0, 150, 0]]);
   });
   it('GREY image', () => {
@@ -53,7 +53,7 @@ describe('Copy a source image to a target', () => {
       [200, 250],
     ]);
     let source = testUtils.createGreyImage([[20]]);
-    const result = source.copyTo(target, { row: 1, column: 1 });
+    const result = source.copyTo(target, { origin: { row: 1, column: 1 } });
     expect(result).toMatchImageData([
       [100, 150],
       [200, 20],
@@ -64,7 +64,7 @@ describe('Copy a source image to a target', () => {
       [100, 150],
       [200, 250],
     ]);
-    const result = target.copyTo(target, { row: 1, column: 1 });
+    const result = target.copyTo(target, { origin: { row: 1, column: 1 } });
     expect(result).toMatchImageData([
       [100, 150],
       [200, 100],
@@ -86,7 +86,7 @@ describe('Copy a source image to a target', () => {
       [100, 100],
     ]);
     let target = testUtils.createGreyImage([[20]]);
-    const result = source.copyTo(target, { row: -1, column: -1 });
+    const result = source.copyTo(target, { origin: { row: -1, column: -1 } });
     expect(result).toMatchImageData([[250]]);
   });
   it('RGBA images', () => {
@@ -96,7 +96,7 @@ describe('Copy a source image to a target', () => {
       [7, 8, 9, 0],
     ]);
     let source = testUtils.createRgbaImage([[3, 3, 3, 255]]);
-    const result = source.copyTo(target, { row: 1, column: 0 });
+    const result = source.copyTo(target, { origin: { row: 1, column: 0 } });
     expect(result).toMatchImageData([
       [1, 2, 3, 255],
       [3, 3, 3, 255],
@@ -132,7 +132,7 @@ describe('Copy a source image to a target', () => {
       [1, 1],
       [1, 1],
     ]);
-    const result = source.copyTo(target, { row: 0, column: 1 });
+    const result = source.copyTo(target, { origin: { row: 0, column: 1 } });
     expect(result).toMatchImageData([
       [0, 1, 1, 0],
       [0, 1, 1, 0],
@@ -146,7 +146,7 @@ describe('Copy a source image to a target', () => {
       [1, 1],
       [1, 1],
     ]);
-    const result = source.copyTo(target, { row: 2, column: 3 });
+    const result = source.copyTo(target, { origin: { row: 2, column: 3 } });
 
     expect(result).toMatchImageData([
       [0, 0, 0, 0],
@@ -161,7 +161,7 @@ describe('Copy a source image to a target', () => {
       [1, 1],
       [1, 1],
     ]);
-    const result = source.copyTo(target, { row: -1, column: 0 });
+    const result = source.copyTo(target, { origin: { row: -1, column: 0 } });
     expect(result).toMatchImageData([
       [1, 1, 0, 0],
       [0, 0, 0, 0],
@@ -179,7 +179,7 @@ describe('Copy a source image to a target', () => {
       [1, 1],
       [1, 1],
     ]);
-    const result = source.copyTo(target, { row: 0, column: 1 });
+    const result = source.copyTo(target, { origin: { row: 0, column: 1 } });
     expect(result).toMatchImageData([
       [0, 1, 1, 1],
       [0, 1, 1, 1],

--- a/src/operations/__tests__/cropAlpha.test.ts
+++ b/src/operations/__tests__/cropAlpha.test.ts
@@ -1,3 +1,5 @@
+import { cropAlpha } from '../cropAlpha';
+
 describe('cropAlpha', () => {
   it('GREYA, no crop', () => {
     const image = testUtils.createGreyaImage([
@@ -7,7 +9,7 @@ describe('cropAlpha', () => {
       [10, 255, 11, 255, 12, 255],
     ]);
 
-    const cropped = image.cropAlpha();
+    const cropped = cropAlpha(image);
     expect(cropped).toMatchImage(image);
   });
 

--- a/src/operations/copyTo.ts
+++ b/src/operations/copyTo.ts
@@ -1,20 +1,14 @@
-import { IJS, Mask } from '..';
+import { IJS, Mask, Point } from '..';
 import { getOutputImage, maskToOutputMask } from '../utils/getOutputImage';
 import { setBlendedPixel } from '../utils/setBlendedPixel';
 
 export interface CopyToOptions<OutType> {
   /**
-   * X offset for the copy, the top left corner of the target image is the reference.
+   * Origin for the crop relative to the top-left corner of the image.
    *
-   * @default 0
+   * @default {row: 0, column: 0}
    */
-  column?: number;
-  /**
-   * Y offset for the copy, the top left corner of the target image is the reference.
-   *
-   * @default 0
-   */
-  row?: number;
+  origin?: Point;
   /**
    * Image to which to output.
    */
@@ -44,7 +38,8 @@ export function copyTo(
   target: IJS | Mask,
   options: CopyToOptions<IJS | Mask> = {},
 ): IJS | Mask {
-  const { column = 0, row = 0 } = options;
+  const { origin = { column: 0, row: 0 } } = options;
+  const { column, row } = origin;
 
   if (source.colorModel !== target.colorModel) {
     throw new Error('Source and target should have the same color model.');

--- a/src/operations/cropAlpha.ts
+++ b/src/operations/cropAlpha.ts
@@ -61,6 +61,7 @@ function findTop(image: IJS, threshold: number, channel: number, left: number) {
       }
     }
   }
+  /* istanbul ignore next */
   return -1;
 }
 
@@ -77,6 +78,7 @@ function findBottom(
       }
     }
   }
+  /* istanbul ignore next */
   return -1;
 }
 
@@ -95,5 +97,6 @@ function findRight(
       }
     }
   }
+  /* istanbul ignore next */
   return -1;
 }


### PR DESCRIPTION
- refactor(floodFill): use origin
- refactor(copyTo): use origin
- test(cropAlpha): fix coverage
