### PR TITLE
refactor: improve performance of separable convolution

### DIFF
--- a/src/utils/__tests__/extendBorders.test.ts
+++ b/src/utils/__tests__/extendBorders.test.ts
@@ -1,0 +1,50 @@
+import { extendBorders } from '../extendBorders';
+
+test('grey image with wrap', () => {
+  const image = testUtils.createGreyImage(`
+    1 2 3 4
+    2 3 4 5
+    3 4 5 6
+    4 5 6 7
+    5 6 7 8
+  `);
+
+  const newImage = extendBorders(image, {
+    horizontal: 2,
+    vertical: 3,
+    borderType: 'wrap',
+  });
+
+  expect(newImage).toMatchImageData(` 
+    5   6   3   4   5   6   3   4
+    6   7   4   5   6   7   4   5
+    7   8   5   6   7   8   5   6
+    3   4   1   2   3   4   1   2
+    4   5   2   3   4   5   2   3
+    5   6   3   4   5   6   3   4
+    6   7   4   5   6   7   4   5
+    7   8   5   6   7   8   5   6
+    3   4   1   2   3   4   1   2
+    4   5   2   3   4   5   2   3
+    5   6   3   4   5   6   3   4
+  `);
+});
+
+test('rgb image with default border type', () => {
+  const image = testUtils.createRgbImage(`
+    1  2  3 | 4  5  6
+    11 12 13| 14 15 16
+  `);
+
+  const newImage = extendBorders(image, {
+    horizontal: 1,
+    vertical: 1,
+  });
+
+  expect(newImage).toMatchImageData(`
+     14  15  16  11  12  13  14  15  16  11  12  13
+      4   5   6   1   2   3   4   5   6   1   2   3
+     14  15  16  11  12  13  14  15  16  11  12  13
+      4   5   6   1   2   3   4   5   6   1   2   3
+  `);
+});

--- a/src/utils/extendBorders.ts
+++ b/src/utils/extendBorders.ts
@@ -1,0 +1,106 @@
+import { Image } from '../Image';
+
+import { BorderType, getBorderInterpolation } from './interpolateBorder';
+
+interface ExtendBordersOptions {
+  horizontal: number;
+  vertical: number;
+  borderType?: BorderType;
+  borderValue?: number;
+}
+
+/**
+ * Extend the borders of an image according to the given border type.
+ *
+ * @param image - Image to extend.
+ * @param options - Options.
+ * @returns A copy of the image with extended borders.
+ */
+export function extendBorders(
+  image: Image,
+  options: ExtendBordersOptions,
+): Image {
+  const {
+    horizontal,
+    vertical,
+    borderType = 'reflect101',
+    borderValue = 0,
+  } = options;
+
+  const interpolateBorder = getBorderInterpolation(borderType, borderValue);
+
+  const newImage = Image.createFrom(image, {
+    width: image.width + 2 * horizontal,
+    height: image.height + 2 * vertical,
+  });
+
+  image.copyTo(newImage, {
+    origin: {
+      column: horizontal,
+      row: vertical,
+    },
+    out: newImage,
+  });
+
+  // Top strip
+  for (let row = 0; row < vertical; row++) {
+    for (let col = 0; col < newImage.width; col++) {
+      for (let channel = 0; channel < image.channels; channel++) {
+        const newValue = interpolateBorder(
+          col - horizontal,
+          row - vertical,
+          channel,
+          image,
+        );
+        newImage.setValue(col, row, channel, newValue);
+      }
+    }
+  }
+
+  // Bottom strip
+  for (let row = newImage.height - vertical; row < newImage.height; row++) {
+    for (let col = 0; col < newImage.width; col++) {
+      for (let channel = 0; channel < image.channels; channel++) {
+        const newValue = interpolateBorder(
+          col - horizontal,
+          row - vertical,
+          channel,
+          image,
+        );
+        newImage.setValue(col, row, channel, newValue);
+      }
+    }
+  }
+
+  // Left strip
+  for (let row = vertical; row < newImage.height - vertical; row++) {
+    for (let col = 0; col < horizontal; col++) {
+      for (let channel = 0; channel < image.channels; channel++) {
+        const newValue = interpolateBorder(
+          col - horizontal,
+          row - vertical,
+          channel,
+          image,
+        );
+        newImage.setValue(col, row, channel, newValue);
+      }
+    }
+  }
+
+  // Right strip
+  for (let row = vertical; row < newImage.height - vertical; row++) {
+    for (let col = newImage.width - horizontal; col < newImage.width; col++) {
+      for (let channel = 0; channel < image.channels; channel++) {
+        const newValue = interpolateBorder(
+          col - horizontal,
+          row - vertical,
+          channel,
+          image,
+        );
+        newImage.setValue(col, row, channel, newValue);
+      }
+    }
+  }
+
+  return newImage;
+}


### PR DESCRIPTION
Use an image with extended borders to avoid the costly manual convolution to handle borders.