### PR TITLE
fix: export channel labels

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export * from './morphology';
 export * from './operations';
 export * from './roi';
 export * from './save';
+export * from './utils/constants/channelLabels';
 export * from './utils/constants/colorModels';
 export { BorderType } from './utils/interpolateBorder';
 export { InterpolationType } from './utils/interpolatePixel';


### PR DESCRIPTION
Channel labels are not exported lib-wide.