### PR TITLE
chore: add additional exports for elements to be seen by typedoc

### DIFF
--- a/src/compute/__tests__/getExtrema.test.ts
+++ b/src/compute/__tests__/getExtrema.test.ts
@@ -1,4 +1,4 @@
-import getExtrema from '../getExtrema';
+import { getExtrema } from '../getExtrema';
 
 test('minimum of grey image from legacy code', () => {
   const image = testUtils.createGreyImage([

--- a/src/compute/getExtrema.ts
+++ b/src/compute/getExtrema.ts
@@ -2,7 +2,7 @@ import { Image, Mask, Point } from '..';
 import { assertUnreachable } from '../utils/validators/assert';
 import checkProcessable from '../utils/validators/checkProcessable';
 
-interface ExtremaOptions {
+export interface ExtremaOptions {
   /**
    * Chooses what kind of extremum to compute.
    * @default `'maximum'`
@@ -30,10 +30,7 @@ interface ExtremaOptions {
  * @param options - ExtremaOptions
  * @returns Array of Points.
  */
-export default function getExtrema(
-  image: Image,
-  options: ExtremaOptions,
-): Point[] {
+export function getExtrema(image: Image, options: ExtremaOptions): Point[] {
   const { kind = 'maximum', mask, algorithm = 'star', maxEquals = 2 } = options;
   checkProcessable(image, {
     bitDepth: [8, 16],

--- a/src/compute/index.ts
+++ b/src/compute/index.ts
@@ -1,3 +1,4 @@
 export * from './mean';
 export * from './histogram';
 export * from './median';
+export * from './getExtrema';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from './draw';
 export * from './featureMatching';
 export * from './filters';
 export * from './geometry';
+export * from './utils/geometry/filterPoints';
 export * from './Image';
 export * from './load';
 export * from './Mask';

--- a/src/roi/waterShed.ts
+++ b/src/roi/waterShed.ts
@@ -3,7 +3,7 @@ import PriorityQueue from 'js-priority-queue';
 import { RoiMapManager } from '..';
 import { Image } from '../Image';
 import { Mask } from '../Mask';
-import getExtrema from '../compute/getExtrema';
+import { getExtrema } from '../compute/getExtrema';
 import { Point } from '../geometry';
 import { filterPoints } from '../utils/geometry/filterPoints';
 import checkProcessable from '../utils/validators/checkProcessable';

--- a/src/utils/geometry/__tests__/filterPoints.test.ts
+++ b/src/utils/geometry/__tests__/filterPoints.test.ts
@@ -1,4 +1,4 @@
-import getExtrema from '../../../compute/getExtrema';
+import { getExtrema } from '../../../compute/getExtrema';
 import { filterPoints } from '../filterPoints';
 
 test('combine minimum points after getExtrema function', () => {

--- a/src/utils/geometry/filterPoints.ts
+++ b/src/utils/geometry/filterPoints.ts
@@ -2,7 +2,7 @@ import { Image } from '../..';
 
 import { Point } from './points';
 
-interface FilterPointsOptions {
+export interface FilterPointsOptions {
   /**
    * The number of points that should be removed if they are close to extremum.
    * @default `0`


### PR DESCRIPTION
add exports for filterPoints and getExtrema so they could be added to typedoc generated documentation.