### PR TITLE
fix: resize nearest

### DIFF
--- a/src/geometry/__tests__/resize.test.ts
+++ b/src/geometry/__tests__/resize.test.ts
@@ -4,20 +4,12 @@ import { encodePng, write } from '../../save';
 
 test('compare result of resize with opencv (nearest)', async () => {
   const img = testUtils.load('opencv/test.png');
-  const expectedImg = testUtils.load('opencv/testResizeNearest.png');
 
   const resized = img.resize({
     xFactor: 10,
     yFactor: 10,
     interpolationType: 'nearest',
   });
-
-  const substraction = expectedImg.clone().subtract(resized);
-  await write(
-    path.join(__dirname, 'resize_nearest_substraction.png'),
-    substraction,
-  );
-  await write(path.join(__dirname, 'resize_nearest.png'), resized);
 
   expect(resized).toMatchImage('opencv/testResizeNearest.png');
 });

--- a/src/geometry/__tests__/resize.test.ts
+++ b/src/geometry/__tests__/resize.test.ts
@@ -1,7 +1,10 @@
-import { encodePng } from '../../save';
+import path from 'node:path';
 
-test.skip('compare result of resize with opencv (nearest)', () => {
+import { encodePng, write } from '../../save';
+
+test('compare result of resize with opencv (nearest)', async () => {
   const img = testUtils.load('opencv/test.png');
+  const expectedImg = testUtils.load('opencv/testResizeNearest.png');
 
   const resized = img.resize({
     xFactor: 10,
@@ -9,16 +12,31 @@ test.skip('compare result of resize with opencv (nearest)', () => {
     interpolationType: 'nearest',
   });
 
+  const substraction = expectedImg.clone().subtract(resized);
+  await write(
+    path.join(__dirname, 'resize_nearest_substraction.png'),
+    substraction,
+  );
+  await write(path.join(__dirname, 'resize_nearest.png'), resized);
+
   expect(resized).toMatchImage('opencv/testResizeNearest.png');
 });
 
-test.skip('compare result of resize with opencv (bilinear)', () => {
+test.skip('compare result of resize with opencv (bilinear)', async () => {
   const img = testUtils.load('opencv/test.png');
+  const expectedImg = testUtils.load('opencv/testResizeBilinear.png');
 
   const resized = img.resize({
     xFactor: 10,
     yFactor: 10,
   });
+
+  const substraction = expectedImg.clone().subtract(resized);
+  await write(
+    path.join(__dirname, 'resize_bilinear_substraction.png'),
+    substraction,
+  );
+  await write(path.join(__dirname, 'resize_bilinear.png'), resized);
 
   expect(resized).toMatchImage('opencv/testResizeBilinear.png');
 });

--- a/src/geometry/resize.ts
+++ b/src/geometry/resize.ts
@@ -1,11 +1,13 @@
 import { Image } from '../Image';
 import { getClamp } from '../utils/clamp';
-import { getBorderInterpolation, BorderType } from '../utils/interpolateBorder';
+import { BorderType, getBorderInterpolation } from '../utils/interpolateBorder';
 import {
   getInterpolationFunction,
   InterpolationType,
 } from '../utils/interpolatePixel';
 import { assert } from '../utils/validators/assert';
+
+import { transform } from './transform';
 
 export interface ResizeOptions {
   /**
@@ -58,7 +60,25 @@ export function resize(image: Image, options: ResizeOptions): Image {
     borderType = 'constant',
     borderValue = 0,
   } = options;
-  const { width, height } = checkOptions(image, options);
+  const { width, height, xFactor, yFactor } = checkOptions(image, options);
+
+  if (interpolationType === 'nearest') {
+    return transform(
+      image,
+      [
+        [xFactor, 0, xFactor / 2],
+        [0, yFactor, yFactor / 2],
+      ],
+      {
+        interpolationType,
+        borderType,
+        borderValue,
+        height,
+        width,
+      },
+    );
+  }
+
   const newImage = Image.createFrom(image, { width, height });
   const interpolate = getInterpolationFunction(interpolationType);
   const interpolateBorder = getBorderInterpolation(borderType, borderValue);


### PR DESCRIPTION
Refs: https://github.com/image-js/image-js-typescript/issues/452

---

chirurgical fix, rework of https://github.com/image-js/image-js-typescript/pull/453

previous PR had lot of issues due to fix for bilinear interpolation breaking lot of tests for general worse results (only clear better results was for the opencv bilinear test).

better / worse are personal appreciation.

This PR fix resize with nearest interpolation by using transform matrix without change `interpolateNearest` function and adding small translation to compensate.
Changing interpolation function would break some tests but not for the best. I continue to think more work need to be done on this topic.

- interpolateNearest should use floor I guess
- compensate with translation may not be the best things to do
- other resize interpolation should also use transform
- maybe the algorithm for transform is not exactly right or be specific for each interpolation method

It's a lot of work to plan for really small, nearly impossible to see with the naked eye and lot of decision and estimation to do to actualize breaking tests or not.